### PR TITLE
Fix ImportError for reverse in Django 2.0 fixes #4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='django-ptrack',
-    version='2.0.0',
+    version='2.1.0',
     description='Ptrack is a tracking pixel library for Django',
     long_description=long_description,
 
@@ -30,6 +30,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/test_ptrack/test_views.py
+++ b/test_ptrack/test_views.py
@@ -2,7 +2,10 @@ import imghdr
 import re
 from mock import MagicMock
 from tempfile import NamedTemporaryFile
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django_webtest import WebTest
 from django.template import engines
 from django.template.loader import render_to_string


### PR DESCRIPTION
The attempts to import reverse from the new location (introduces in Django 1.10). Then falls back to the previous method on ImportError. 

The fallback is to maintain Django 1.8, 1.9 support. 
This fixes #4 