### PR TITLE
DJANGO-1511: Update urls to remove RemovedInDjango40Warning: django.c…

### DIFF
--- a/ptrack/__init__.py
+++ b/ptrack/__init__.py
@@ -26,6 +26,7 @@ def autodiscover():
 class TrackingPixel(object):
     """The custom tracking pixel registered by tracker."""
     __metaclass__ = abc.ABCMeta
+
     @abc.abstractmethod
     def record(self, *args, **kwargs):
         """Callback executed when the tracking pixel img loads."""

--- a/ptrack/urls.py
+++ b/ptrack/urls.py
@@ -1,8 +1,8 @@
 """ Ptrack Django URL Configuration """
-from django.conf.urls import url
+from django.urls import re_path
 from ptrack.views import TrackingPixel
 
 
 urlpatterns = [
-    url(r'^(?P<ptrack_encoded_data>.*?)/$', TrackingPixel.as_view(), name="ptrack"),
+    re_path(r'^(?P<ptrack_encoded_data>.*?)/$', TrackingPixel.as_view(), name="ptrack"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='django-ptrack',
-    version='2.2.2',
+    version='3.0.0',
     description='Ptrack is a tracking pixel library for Django',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -27,14 +27,8 @@ setup(
         'Intended Audience :: Developers',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
@@ -43,7 +37,7 @@ setup(
 
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests', 'example_project']),
     install_requires=[
-        'Django>=1.8.1',
+        'Django>=2.0.0',
         'pynacl>=1.0.1'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='django-ptrack',
-    version='2.2.1',
+    version='2.2.2',
     description='Ptrack is a tracking pixel library for Django',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Update to prevent depreciation warning: RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().